### PR TITLE
tplink-safeloader: add support for TPLink Archer A7 v5 (RU)

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -725,7 +725,8 @@ static struct device_info boards[] = {
 			"{product_name:Archer A7,product_ver:5.0.0,special_id:55530000}\n"
 			"{product_name:Archer A7,product_ver:5.0.0,special_id:43410000}\n"
 			"{product_name:Archer A7,product_ver:5.0.0,special_id:4A500000}\n"
-			"{product_name:Archer A7,product_ver:5.0.0,special_id:54570000}\n",
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:54570000}\n"
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:52550000}\n",
 		.part_trail = 0x00,
 		.soft_ver = "soft_ver:1.0.0\n",
 


### PR DESCRIPTION
This adds support for another variant of TPLink Archer A7 v5 (RU) which
should be the same as Archer C7 v5. Other special_ids from C7 may be considered
but I have only this one tested on my hardware

Signed-off-by: Alexey Kunitskiy <alexey.kv@gmail.com>